### PR TITLE
fix(locany): fallback to sdpa for eager attention and document processor output type mismatch

### DIFF
--- a/Embodied/eaglevl/model/locany/modeling_qwen2.py
+++ b/Embodied/eaglevl/model/locany/modeling_qwen2.py
@@ -1099,7 +1099,11 @@ class Qwen2Model(Qwen2PreTrainedModel):
         self.layers = nn.ModuleList(
             [Qwen2DecoderLayer(config, layer_idx) for layer_idx in range(config.num_hidden_layers)]
         )
-        self._attn_implementation = config._attn_implementation
+        self._attn_implementation = (
+            config._attn_implementation
+            if config._attn_implementation in ["magi", "sdpa"]
+            else "sdpa"
+        )
         self.norm = Qwen2RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
 
         self.gradient_checkpointing = False

--- a/Embodied/eaglevl/utils/locany/modeling_qwen2.py
+++ b/Embodied/eaglevl/utils/locany/modeling_qwen2.py
@@ -1158,7 +1158,11 @@ class Qwen2Model(Qwen2PreTrainedModel):
         self.layers = nn.ModuleList(
             [Qwen2DecoderLayer(config, layer_idx) for layer_idx in range(config.num_hidden_layers)]
         )
-        self._attn_implementation = config._attn_implementation
+        self._attn_implementation = (
+            config._attn_implementation
+            if config._attn_implementation in ["magi", "sdpa"]
+            else "sdpa"
+        )
         self.norm = Qwen2RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
 
         self.gradient_checkpointing = False


### PR DESCRIPTION
### Description
This PR addresses a critical architecture compatibility crash discovered when initializing `nvidia/LocateAnything-3B` models using recent versions of the Hugging Face `transformers` upstream library (v4.49.0+).

1. **Attention Routing Bug**: Recent versions of `transformers` initialize `config._attn_implementation` to `"eager"` by default under certain hardware/software configurations. Because `Qwen2Model.forward()` explicitly restricts attention checks exclusively to `"magi"` and `"sdpa"`, execution fails immediately with a `NotImplementedError: self._attn_implementation='eager'`. This patch safely enforces an `"sdpa"` fallback when unexpected values are received.
2. **API and Script Redundancy**: The patch has been applied identically across both redundant copies of `modeling_qwen2.py` found within the repository tree to prevent structural discrepancies. Additionally, note that `model.generate()` evaluates directly to a serialized XML `str` rather than returning typical token IDs (`torch.LongTensor`), breaking standard downstream helpers like `processor.post_process_generation()`.

### Changes Made
- Modified `modeling_qwen2.py` to evaluate incoming `config._attn_implementation` states and route them smoothly into `"sdpa"` instead of raising a `NotImplementedError`.
- Synced and deployed the change simultaneously across both paths:
  1. `Embodied/eaglevl/utils/locany/modeling_qwen2.py`
  2. `Embodied/eaglevl/models/locany/modeling_qwen2.py`

### Checklists
- [x] My code follows the code style of this project.
- [x] I have verified that this fix prevents the attention router from crashing.